### PR TITLE
Make throttle responses more comprehensive,

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -30,7 +30,7 @@ Rack::Attack.throttle('apiv2/5m', limit: ENV['THROTTLE_API_5MIN'].to_i, period: 
   end
 end
 
-Rack::Attack.throttle('apiv2-non-gzip/1h', limit: 6, period: 1.minute) do |req|
+Rack::Attack.throttle('apiv2-non-gzip/1m', limit: 6, period: 1.minute) do |req|
   if req.path.start_with?('/api/v2/')
     if !req.env.include?('HTTP_ACCEPT_ENCODING') || (req.env['HTTP_ACCEPT_ENCODING'].split(',') & ['gzip', 'deflate', 'br', 'zstd']).size == 0
       req.ip
@@ -39,6 +39,7 @@ Rack::Attack.throttle('apiv2-non-gzip/1h', limit: 6, period: 1.minute) do |req|
 end
 
 Rack::Attack.throttled_responder = lambda do |request|
+  matched = request.env['rack.attack.matched']
   match_data = request.env['rack.attack.match_data']
   now = match_data[:epoch_time]
 
@@ -48,10 +49,9 @@ Rack::Attack.throttled_responder = lambda do |request|
     'RateLimit-Reset' => (now + (match_data[:period] - now % match_data[:period])).to_s
   }
 
-  if request.env['rack.attack.matched'] == 'apiv2-non-gzip/1h'
+  if matched == 'apiv2-non-gzip/1m'
     [ 429, headers, ["Throttled, be nice to the server, use compression (gzip, deflate, etc)! Throttle resets at #{Time.at(now + (match_data[:period] - now % match_data[:period]))}!\n"]]
   else
-    [ 429, headers, ["Throttled, slow down!\n"]]
+    [ 429, headers, ["Throttled, slow down! You exceeded the throttle #{matched} that limits requests to #{match_data[:limit]} per #{match_data[:period]} seconds! Throttle resets at #{Time.at(now + (match_data[:period] - now % match_data[:period]))}!\n"]]
   end
 end
-

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ echo "Running: ${RUN_MODE}"
 cd /rails
 
 case ${RUN_MODE} in
-  coonsole)
+  console)
     check_db
     echo "Service type is console"
     bundle exec rails c


### PR DESCRIPTION
Send responses that are easier to understand, like
`Throttled, slow down! You exceeded the throttle apiv2/1m that limits requests to 100 per 60 seconds! Throttle resets at 2024-10-18 14:55:00 +0000`

Also fixed a typo.