### PR TITLE
Change identifier expiration from 10 mins to 1 hour

### DIFF
--- a/app/services/identifier_service.rb
+++ b/app/services/identifier_service.rb
@@ -1,5 +1,5 @@
 class IdentifierService
-  def self.add_identifier_event(opts, server, event, natsmsg = nil, expiration = 600)
+  def self.add_identifier_event(opts, server, event, natsmsg = nil, expiration = 3600)
 
     # Ensure opts is a hash
     opts = opts.is_a?(Hash) ? opts : JSON.parse(opts) rescue {}


### PR DESCRIPTION
10 mins is too little time to explain to people how to see and copy the identifier.