### PR TITLE
refactor location ID validation in deduplication services to ensure only valid market location IDs are processed

### DIFF
--- a/app/services/market_history_dedupe_service.rb
+++ b/app/services/market_history_dedupe_service.rb
@@ -30,7 +30,7 @@ class MarketHistoryDedupeService
     if REDIS[server_id].get("HISTORY_RECORD_SHA256:#{sha256}").nil?
       REDIS[server_id].set("HISTORY_RECORD_SHA256:#{sha256}", '1', ex: 600)
       return if data['AlbionId'] == 0 # sometimes the client sends us 0 for the numeric item id, we trash this data
-      return if !data['LocationId'].is_a?(Numeric) || CITY_TO_LOCATION.has_value?(data['LocationId']) # we only want to process numeric location ids from known cities
+      return if !data['LocationId'].is_a?(Numeric) || !CITY_TO_LOCATION.has_value?(data['LocationId']) # we only want to process numeric location ids from known cities
 
       item_id = REDIS[server_id].hget('ITEM_IDS', data['AlbionId'])
       raise StandardError.new('MarketHistoryProcessorService: Item ID not found in redis.') if item_id.nil?

--- a/app/services/market_history_dedupe_service.rb
+++ b/app/services/market_history_dedupe_service.rb
@@ -30,7 +30,7 @@ class MarketHistoryDedupeService
     if REDIS[server_id].get("HISTORY_RECORD_SHA256:#{sha256}").nil?
       REDIS[server_id].set("HISTORY_RECORD_SHA256:#{sha256}", '1', ex: 600)
       return if data['AlbionId'] == 0 # sometimes the client sends us 0 for the numeric item id, we trash this data
-      return if !data['LocationId'].is_a?(Numeric) || !LOCATION_TO_CITY.has_value?(data['LocationId']) # we only want to process numeric location ids from known cities
+      return if !data['LocationId'].is_a?(Numeric) || CITY_TO_LOCATION.has_value?(data['LocationId']) # we only want to process numeric location ids from known cities
 
       item_id = REDIS[server_id].hget('ITEM_IDS', data['AlbionId'])
       raise StandardError.new('MarketHistoryProcessorService: Item ID not found in redis.') if item_id.nil?

--- a/app/services/market_history_dedupe_service.rb
+++ b/app/services/market_history_dedupe_service.rb
@@ -30,7 +30,7 @@ class MarketHistoryDedupeService
     if REDIS[server_id].get("HISTORY_RECORD_SHA256:#{sha256}").nil?
       REDIS[server_id].set("HISTORY_RECORD_SHA256:#{sha256}", '1', ex: 600)
       return if data['AlbionId'] == 0 # sometimes the client sends us 0 for the numeric item id, we trash this data
-      return if !data['LocationId'].is_a?(Numeric) || !CITY_TO_LOCATION.has_value?(data['LocationId']) # we only want to process numeric location ids from known cities
+      return if !data['LocationId'].is_a?(Numeric) || (!CITY_TO_LOCATION.has_value?(data['LocationId'].to_i) && !PORTAL_TO_CITY.has_key?(data['LocationId'].to_i)) # we only want to process numeric location ids from known cities or portals
 
       item_id = REDIS[server_id].hget('ITEM_IDS', data['AlbionId'])
       raise StandardError.new('MarketHistoryProcessorService: Item ID not found in redis.') if item_id.nil?

--- a/app/services/market_history_dedupe_service.rb
+++ b/app/services/market_history_dedupe_service.rb
@@ -30,7 +30,7 @@ class MarketHistoryDedupeService
     if REDIS[server_id].get("HISTORY_RECORD_SHA256:#{sha256}").nil?
       REDIS[server_id].set("HISTORY_RECORD_SHA256:#{sha256}", '1', ex: 600)
       return if data['AlbionId'] == 0 # sometimes the client sends us 0 for the numeric item id, we trash this data
-      return if data['LocationId'] == 0 || !data['LocationId'].is_a?(Numeric)  # sometimes the client sends us 0 for the numeric location id, or a string, we trash this data
+      return if !data['LocationId'].is_a?(Numeric) || !LOCATION_TO_CITY.has_value?(data['LocationId']) # we only want to process numeric location ids from known cities
 
       item_id = REDIS[server_id].hget('ITEM_IDS', data['AlbionId'])
       raise StandardError.new('MarketHistoryProcessorService: Item ID not found in redis.') if item_id.nil?

--- a/app/services/market_order_dedupe_service.rb
+++ b/app/services/market_order_dedupe_service.rb
@@ -59,7 +59,7 @@ class MarketOrderDedupeService
         if REDIS[@server_id].get("RECORD_SHA256:#{sha256}").nil?
           REDIS[@server_id].set("RECORD_SHA256:#{sha256}", '1', ex: 600)
 
-          next if order['LocationId'] == 0 || !order['LocationId'].is_a?(Numeric)  # sometimes the client sends us 0 for the numeric location id, or a string, we trash this data
+          next if !order['LocationId'].is_a?(Numeric) || !LOCATION_TO_CITY.has_value?(order['LocationId']) # we only want to process numeric location ids from known cities
 
           # Hack since albion seems to be multiplying every price by 10000
           order['UnitPriceSilver'] /= 10000

--- a/app/services/market_order_dedupe_service.rb
+++ b/app/services/market_order_dedupe_service.rb
@@ -59,7 +59,7 @@ class MarketOrderDedupeService
         if REDIS[@server_id].get("RECORD_SHA256:#{sha256}").nil?
           REDIS[@server_id].set("RECORD_SHA256:#{sha256}", '1', ex: 600)
 
-          next if !order['LocationId'].is_a?(Numeric) || !CITY_TO_LOCATION.has_value?(order['LocationId']) # we only want to process numeric location ids from known cities
+          next if !order['LocationId'].is_a?(Numeric) || (!CITY_TO_LOCATION.values.include?(order['LocationId'].to_i) && !PORTAL_TO_CITY.has_key?(order['LocationId'].to_i))
 
           # Hack since albion seems to be multiplying every price by 10000
           order['UnitPriceSilver'] /= 10000

--- a/app/services/market_order_dedupe_service.rb
+++ b/app/services/market_order_dedupe_service.rb
@@ -59,7 +59,7 @@ class MarketOrderDedupeService
         if REDIS[@server_id].get("RECORD_SHA256:#{sha256}").nil?
           REDIS[@server_id].set("RECORD_SHA256:#{sha256}", '1', ex: 600)
 
-          next if !order['LocationId'].is_a?(Numeric) || CITY_TO_LOCATION.has_value?(order['LocationId']) # we only want to process numeric location ids from known cities
+          next if !order['LocationId'].is_a?(Numeric) || !CITY_TO_LOCATION.has_value?(order['LocationId']) # we only want to process numeric location ids from known cities
 
           # Hack since albion seems to be multiplying every price by 10000
           order['UnitPriceSilver'] /= 10000

--- a/app/services/market_order_dedupe_service.rb
+++ b/app/services/market_order_dedupe_service.rb
@@ -59,7 +59,7 @@ class MarketOrderDedupeService
         if REDIS[@server_id].get("RECORD_SHA256:#{sha256}").nil?
           REDIS[@server_id].set("RECORD_SHA256:#{sha256}", '1', ex: 600)
 
-          next if !order['LocationId'].is_a?(Numeric) || !LOCATION_TO_CITY.has_value?(order['LocationId']) # we only want to process numeric location ids from known cities
+          next if !order['LocationId'].is_a?(Numeric) || CITY_TO_LOCATION.has_value?(order['LocationId']) # we only want to process numeric location ids from known cities
 
           # Hack since albion seems to be multiplying every price by 10000
           order['UnitPriceSilver'] /= 10000

--- a/spec/app/services/market_history_dedupe_service_spec.rb
+++ b/spec/app/services/market_history_dedupe_service_spec.rb
@@ -67,8 +67,8 @@ describe MarketHistoryDedupeService, type: :service do
     end
 
     it 'will not convert the LocationId if it is not a portal' do
-      data = { 'foo' => 'bar', 'AlbionId' => 1234, 'LocationId' => 1234, 'MarketHistories' => [] }
-      expected_data = { 'foo' => 'bar', 'AlbionId' => 1234, 'LocationId' => 1234, 'MarketHistories' => [], 'AlbionIdString' => 'SOME_ITEM_ID', }
+      data = { 'foo' => 'bar', 'AlbionId' => 1234, 'LocationId' => 3005, 'MarketHistories' => [] }
+      expected_data = { 'foo' => 'bar', 'AlbionId' => 1234, 'LocationId' => 3005, 'MarketHistories' => [], 'AlbionIdString' => 'SOME_ITEM_ID', }
       allow(REDIS['west']).to receive(:get).and_return(nil)
       allow(REDIS['west']).to receive(:hget).with('ITEM_IDS', 1234).and_return('SOME_ITEM_ID')
 
@@ -82,8 +82,8 @@ describe MarketHistoryDedupeService, type: :service do
     end
 
     it 'corrects the price of the MarketHistories' do
-      data = { 'foo' => 'bar', 'AlbionId' => 1234, 'LocationId' => 1234, 'MarketHistories' => [{ 'SilverAmount' => '123456' }] }
-      expected_data = { 'foo' => 'bar', 'AlbionId' => 1234, 'LocationId' => 1234, 'MarketHistories' => [{ 'SilverAmount' => 12 }] , 'AlbionIdString' => 'SOME_ITEM_ID', }
+      data = { 'foo' => 'bar', 'AlbionId' => 1234, 'LocationId' => 3005, 'MarketHistories' => [{ 'SilverAmount' => '123456' }] }
+      expected_data = { 'foo' => 'bar', 'AlbionId' => 1234, 'LocationId' => 3005, 'MarketHistories' => [{ 'SilverAmount' => 12 }] , 'AlbionIdString' => 'SOME_ITEM_ID', }
       allow(REDIS['west']).to receive(:get).and_return(nil)
       allow(REDIS['west']).to receive(:hget).with('ITEM_IDS', 1234).and_return('SOME_ITEM_ID')
 

--- a/spec/app/services/market_history_dedupe_service_spec.rb
+++ b/spec/app/services/market_history_dedupe_service_spec.rb
@@ -18,7 +18,7 @@ describe MarketHistoryDedupeService, type: :service do
       expect(subject.dedupe(data, 'west', opts)).to eq(nil)
     end
 
-    it 'returns nil if LocationId is 0' do
+    it 'returns nil if LocationId is not a valid market locationId' do
       data = { 'LocationId' => 0 }
       expect(subject.dedupe(data, 'west', opts)).to eq(nil)
     end

--- a/spec/app/services/market_order_dedupe_service_spec.rb
+++ b/spec/app/services/market_order_dedupe_service_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe MarketOrderDedupeService, type: :subject do
       end
     end
 
-    context 'when order has LocationId equal to 0' do
+    context 'when order has a LocationId that is not a valid market locationId' do
       before do
         data['Orders'].first['LocationId'] = 0
       end

--- a/spec/app/services/market_order_dedupe_service_spec.rb
+++ b/spec/app/services/market_order_dedupe_service_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe MarketOrderDedupeService, type: :subject do
       end
 
       it 'does not merge non-portal locations' do
-        data['Orders'].first['LocationId'] = 5000
+        data['Orders'].first['LocationId'] = 3005
         result = subject.dedupe
-        expect(result.first['LocationId']).to eq(5000)
+        expect(result.first['LocationId']).to eq(3005)
       end
     end
 


### PR DESCRIPTION
I don't think new test were needed. The '0' test already had it covered. And there's an existing test for valid Ids.