### PR TITLE
Add Royal Forge to third-party tools list

### DIFF
--- a/app/views/pages/third_party_tools.html.erb
+++ b/app/views/pages/third_party_tools.html.erb
@@ -25,6 +25,7 @@
         <li><%= link_to "Albionix Tools", "https://albionix.app/", target: "_blank", rel: "noopener" %> is a calculator for Transporting Item profitability and some market analysis. Maintained by Discord User Kytavian#4406.</li>
         <li><%= link_to "Albion Online Tools", "https://albiononlinetools.com/", target: "_blank", rel: "noopener" %> is a site with a bunch of tools for Albion Online users. Maintained by Discord User legita.</li>
         <li><%= link_to "Albion Online Grind", "https://albiononlinegrind.com/", target: "_blank", rel: "noopener" %> offers a multifaceted toolkit that empowers you to manage islands efficiently, organise your stored items seamlessly, create visual Avalonian road maps, stay on top of important timers, calculate item enchantments with ease, and maximise farming profits. And much more. Maintained by Discord User ummahusla.</li>
+        <li><%= link_to "Royal Forge", "https://royalforge.crintech.pro", target: "_blank", rel: "noopener" %> is a free fan-made companion app for Albion Online. Browse market prices by category with tier &amp; enchantment selectors, track kill events, search players &amp; guilds, create and share builds, and monitor gold prices.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
Adds [Royal Forge](https://royalforge.crintech.pro) to the list of community tools built on AODP.

Royal Forge is a free companion app for Albion Online that lets players browse market prices by category with tier & enchantment selectors, track kill events, search players & guilds, create and share builds, and monitor gold prices.