### PR TITLE
Add Vigil Bot to third-party tools

### DIFF
--- a/app/views/pages/third_party_tools.html.erb
+++ b/app/views/pages/third_party_tools.html.erb
@@ -26,6 +26,7 @@
         <li><%= link_to "Albion Online Tools", "https://albiononlinetools.com/", target: "_blank", rel: "noopener" %> is a site with a bunch of tools for Albion Online users. Maintained by Discord User legita.</li>
         <li><%= link_to "Albion Online Grind", "https://albiononlinegrind.com/", target: "_blank", rel: "noopener" %> offers a multifaceted toolkit that empowers you to manage islands efficiently, organise your stored items seamlessly, create visual Avalonian road maps, stay on top of important timers, calculate item enchantments with ease, and maximise farming profits. And much more. Maintained by Discord User ummahusla.</li>
         <li><%= link_to "Royal Forge", "https://royalforge.crintech.pro", target: "_blank", rel: "noopener" %> is a free fan-made companion app for Albion Online. Browse market prices by category with tier &amp; enchantment selectors, track kill events, search players &amp; guilds, create and share builds, and monitor gold prices.</li>
+        <li><%= link_to "Vigil Bot", "https://vigil.crintech.pro", target: "_blank", rel: "noopener" %> is a Discord bot for Albion Online guilds. Live killboard, guild economy (balances, fines, regear cost with market prices), ZvZ attendance tracking, text-to-speech announcements, and a web dashboard with Discord OAuth. Free tier plus optional premium.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
Adds Vigil Bot, a Discord bot for Albion Online guilds that uses AODP market data for the `/precio`, `/oro`, and `/regear` commands (item prices, gold prices, replacement-cost calculations for killed gear).

Attribution to AODP is visible in the bot's embed footers on those commands and in the dashboard landing + legal pages at https://vigil.crintech.pro/legal/privacy.

Same author as Royal Forge (already listed in the preceding line).

- URL: https://vigil.crintech.pro
- Source: https://github.com/Crinlorite/vigil-discordbot