### PR TITLE
Add Albion Online Builds link to third party tools

### DIFF
--- a/app/views/pages/third_party_tools.html.erb
+++ b/app/views/pages/third_party_tools.html.erb
@@ -26,6 +26,7 @@
         <li><%= link_to "Albion Online Tools", "https://albiononlinetools.com/", target: "_blank", rel: "noopener" %> is a site with a bunch of tools for Albion Online users. Maintained by Discord User legita.</li>
         <li><%= link_to "Albion Online Grind", "https://albiononlinegrind.com/", target: "_blank", rel: "noopener" %> offers a multifaceted toolkit that empowers you to manage islands efficiently, organise your stored items seamlessly, create visual Avalonian road maps, stay on top of important timers, calculate item enchantments with ease, and maximise farming profits. And much more. Maintained by Discord User ummahusla.</li>
         <li><%= link_to "Royal Forge", "https://royalforge.crintech.pro", target: "_blank", rel: "noopener" %> is a free fan-made companion app for Albion Online. Browse market prices by category with tier &amp; enchantment selectors, track kill events, search players &amp; guilds, create and share builds, and monitor gold prices.</li>
+        <li><%= link_to "Albion Online Builds", "https://www.albiononlinebuilds.com/", target: "_blank", rel: "noopener" %> helps you browse and share builds for different activities, check the market prices, look up player stats, and use tools such as a craft-profit calculator. The site is available in several languages.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
We use the albion-online-data to power market and gold data in the website.

https://www.albiononlinebuilds.com/market
https://www.albiononlinebuilds.com/market/gold-price
https://www.albiononlinebuilds.com/market/premium-prices