### PR TITLE
Add Albion Online Hub to third-party tools list

### DIFF
--- a/app/views/pages/third_party_tools.html.erb
+++ b/app/views/pages/third_party_tools.html.erb
@@ -27,6 +27,7 @@
         <li><%= link_to "Albion Profit", "https://albion.icaruk.dev", target: "_blank", rel: "noopener" %> is a tool that enables users to semi-automatically calculate the profit of any combination of one product with multiple ingredients.</li>
         <li><%= link_to "Albion Online Builds", "https://www.albiononlinebuilds.com/", target: "_blank", rel: "noopener" %> helps you browse and share builds for different activities, check the market prices, look up player stats, and use tools such as a craft-profit calculator. The site is available in several languages.</li>
         <li><%= link_to "Albion Ultimate", "https://www.albion-ultimate.com/", target: "_blank", rel: "noopener" %> provides Albion Online crafting and market tools, including profit calculators, price checking, focus optimization, cheaper crafting paths, black market planning, best deals, and resource planning to help players make better economic decisions.</li>
+        <li><%= link_to "Albion Online Hub", "https://albiononlinehub.com/", target: "_blank", rel: "noopener" %> is an economy-focused toolkit for Albion Online traders and crafters, featuring live market flips (including transport routes and enchant flipping), crafting and refining calculators, craft planning tools, order tracker, meta builds, and beginner guides. All regional servers are supported.</li>
       </ul>
     </section>
 


### PR DESCRIPTION
All features that use data from the AODP are free to use. I clarify we do have a donor role, which gives access to a small set of 'quality of life' features, but it's not like we are gating public data behind a paywall.